### PR TITLE
FIX: Only invoke destroy if it exists

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,9 @@ module.exports.useAsyncEffect = (effect, destroy, inputs) => {
   useEffect(() => {
     let result;
     effect().then((value) => result = value);
-
-    return () => destroy(result);
+    
+    if(typeof destroy === 'function'){
+      return () => destroy(result);
+    }
   }, inputs);
 };


### PR DESCRIPTION
Fixes a bug, where it crashes if `destroy` isn't passed. Adheres to the TypeScript typings, where `destroy` is optional