### PR TITLE
Added isMounted() and fixed bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,14 @@
 [![npm version](https://badge.fury.io/js/use-async-effect.svg)](https://www.npmjs.com/package/use-async-effect)
 
 # use-async-effect
+
 :running: Asynchronous side effects, without the nonsense
+
+```javascript
+useAsyncEffect(async () => {
+  await doSomethingAsync();
+});
+```
 
 ## Installation
 
@@ -14,6 +21,36 @@ yarn add use-async-effect
 ```
 
 This package includes TypeScript and Flow types.
+
+## API
+
+The API is the same as React's `useEffect()`, except for some notable differences:
+
+- The destroy function is passed as the second argument
+- The main function receives an `isMounted()`, which every time it's called will check for the status.
+
+This hook signatures are:
+
+```javascript
+useAsyncEffect(callback, dependencies);
+useAsyncEffect(callback, onUnmount, dependencies);
+```
+
+The async callback will receive a single function to check whether the component is still mounted:
+
+```javascript
+useAsyncEffect(async isMounted => {
+  const data1 = await fn1();
+  if (!isMounted()) return;
+
+  const data2 = await fn2();
+  if (!isMounted()) return;
+
+  doSomething(data1, data2);
+});
+```
+
+
 
 ## Examples
 
@@ -30,4 +67,22 @@ useAsyncEffect(async () => console.log('mount'), []);
 Handle effect result in destroy
 ```javascript
 useAsyncEffect(() => fetch('url'), (result) => console.log(result));
+```
+
+Making sure it's still mounted before updating component state:
+
+```javascript
+const User = () => 
+  const [user, setUser] = useState(false);
+
+  useAsyncEffect(async isMounted => {
+    const data = await fetch(`/users/${id}`).then(res => res.json());
+    // Add a check to make sure it's still mounted before updating
+    if (!isMounted()) return;
+    setUser(data);
+  }, [id]);
+
+  if (!user) return null;
+  return <div>{user.name}</div>;
+};
 ```

--- a/index.js
+++ b/index.js
@@ -6,7 +6,8 @@ module.exports.useAsyncEffect = (effect, destroy, inputs) => {
 
   useEffect(() => {
     let result;
-    effect(() => mounted.current).then((value) => result = value);
+    const maybePromise = effect(() => mounted.current);
+    Promise.resolve(maybePromise).then((value) => result = value);
 
     return () => {
       mounted.current = false;

--- a/index.js
+++ b/index.js
@@ -1,14 +1,18 @@
-const { useEffect } = require('react');
+const { useEffect, useRef } = require('react');
 
 module.exports.useAsyncEffect = (effect, destroy, inputs) => {
   const hasDestroy = typeof destroy === 'function';
+  const mounted = useRef(true);
 
   useEffect(() => {
     let result;
-    effect().then((value) => result = value);
+    effect(() => mounted.current).then((value) => result = value);
 
-    if (hasDestroy) {
-      return () => destroy(result);
-    }
+    return () => {
+      mounted.current = false;
+      if (hasDestroy) {
+        destroy(result);
+      }
+    };
   }, hasDestroy ? inputs : destroy);
 };


### PR DESCRIPTION
Hey great library! I've been doing something similar for a while, but still find issues when I have an async function and then the component might have unmounted after some async state happens. 

Added `isMounted()`. With it, you can check that the component is still mounted before doing anything with the data:

```js
const User = () => 
  const [user, setUser] = useState(false);

  useAsyncEffect(async isMounted => {
    const data = await fetch(`/users/${id}`).then(res => res.json());
    // Add a check to make sure it's still mounted before updating
    if (!isMounted()) return;
    setUser(data);
  }, [id]);

  if (!user) return null;
  return <div>{user.name}</div>;
};
```

Added a wrap with `Promise.resolve()` to make sure it's always a promise, even in the cases where we are calling it with a sync function. This is very useful because then you can use only `useAsyncEffect` instead of having to switch between both implementations:

```js
import useEffect from 'use-async-effect';
```

Added documentation about everything.