### PR TITLE
Fixed bug with stale isMounted()

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,3 @@
-
 const { useEffect, useRef } = require("react");
 
 const useAsyncEffect = (effect, destroy, inputs) => {

--- a/index.js
+++ b/index.js
@@ -1,21 +1,32 @@
-const { useEffect, useRef } = require('react');
 
-module.exports.useAsyncEffect = (effect, destroy, inputs) => {
-  const hasDestroy = typeof destroy === 'function';
+const { useEffect, useRef } = require("react");
+
+const useAsyncEffect = (effect, destroy, inputs) => {
+  const hasDestroy = typeof destroy === "function";
   const mounted = useRef(true);
 
+  useEffect(
+    () => {
+      let result;
+      const maybePromise = effect(() => mounted.current);
+
+      Promise.resolve(maybePromise).then(value => {
+        result = value;
+      });
+
+      if (hasDestroy) return () => destroy(result);
+    },
+    hasDestroy ? inputs : destroy
+  );
+
+  // This will only happen when the component is unmounted,
+  // not when the dependencies change
   useEffect(() => {
-    let result;
-    const maybePromise = effect(() => mounted.current);
-
-    Promise.resolve(maybePromise).then((value) => result = value);
-
     return () => {
       mounted.current = false;
-
-      if (hasDestroy) {
-        destroy(result);
-      }
     };
-  }, hasDestroy ? inputs : destroy);
+  }, []);
 };
+
+module.exports = useAsyncEffect;
+module.exports.useAsyncEffect = useAsyncEffect;


### PR DESCRIPTION
It worked always that I used it because I was using an empty dependency array `[]`. But if the dependency changes, it will call `mounted.current = false` even if it's still mounted with different deps. With this fix, it will only unmount on an actual unmount.

Also: linted the code with Prettier and exporting a default so you can do

```js
import useAsyncEffect from 'use-async-effect';
```

Since this is a wrapper 100% compatible with `useEffect()`, you can also do:

```js
import useEffect from 'use-async-effect';
```

See here the different options:

https://codesandbox.io/s/inspiring-mahavira-d0zf3

You can change the require path from `"./use-async-effect"` to `"./use-async-effect-old"` to see the bug in action when seeing a specific pokemon and clicking on prev-next.