### PR TITLE
Fixed stale isMounted() bug

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,21 +2,20 @@ const { useEffect, useRef } = require('react');
 
 const useAsyncEffect = (effect, destroy, inputs) => {
   const hasDestroy = typeof destroy === 'function';
-  const mounted = useRef();
 
   useEffect(
     () => {
-      mounted.current = true;
-
       let result;
-      const maybePromise = effect(() => mounted.current);
+      let mounted = true;
+
+      const maybePromise = effect(() => mounted);
 
       Promise.resolve(maybePromise).then(value => {
         result = value;
       });
 
       return () => {
-        mounted.current = false;
+        mounted = false;
 
         if (hasDestroy) {
           destroy(result);


### PR DESCRIPTION
As discussed in the issue #10, it also fixes a bug where it might return `true` even if that callback was already unmounted. If it's unmounted, it should display false even if a later version has been mounted, right?