### PR TITLE
Allow to use in React 17

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "author": "Raul de Heer",
   "license": "MIT",
   "peerDependencies": {
-    "react": "^16.8.0"
+    "react": "^16.8.0 || ^17.0.0"
   },
   "devDependencies": {
     "@types/react": "^16.9.2",


### PR DESCRIPTION
When trying to install in React 17 you get this error:

```
npm i use-async-effect
npm ERR! code ERESOLVE
npm ERR! ERESOLVE unable to resolve dependency tree
npm ERR! 
npm ERR! While resolving: covid-19_tracker@0.1.0
npm ERR! Found: react@17.0.1
npm ERR! node_modules/react
npm ERR!   react@"^17.0.1" from the root project
npm ERR! 
npm ERR! Could not resolve dependency:
npm ERR! peer react@"^16.8.0" from use-async-effect@2.2.2
npm ERR! node_modules/use-async-effect
npm ERR!   use-async-effect@"*" from the root project
npm ERR! 
npm ERR! Fix the upstream dependency conflict, or retry
npm ERR! this command with --force, or --legacy-peer-deps
npm ERR! to accept an incorrect (and potentially broken) dependency resolution.
npm ERR! 
npm ERR! See /Users/standard/.npm/eresolve-report.txt for a full report.

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/standard/.npm/_logs/2021-02-26T03_32_42_811Z-debug.log
```

With these changes, it will work in the newer React.