### PR TITLE
Rename `isActive` effect argument to `isMounted` in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,12 +38,12 @@ useAsyncEffect(callback, onDestroy, dependencies?);
 - The async callback will receive a single function to check whether the callback is still active:
 
 ```javascript
-useAsyncEffect(async isActive => {
+useAsyncEffect(async isMounted => {
   const data1 = await fn1();
-  if (!isActive()) return;
+  if (!isMounted()) return;
 
   const data2 = await fn2();
-  if (!isActive()) return;
+  if (!isMounted()) return;
 
   doSomething(data1, data2);
 });
@@ -70,9 +70,9 @@ useAsyncEffect(() => fetch('url'), (result) => console.log(result));
 
 Making sure it's still active before updating component state
 ```javascript
-useAsyncEffect(async isActive => {
+useAsyncEffect(async isMounted => {
   const data = await fetch(`/users/${id}`).then(res => res.json());
-  if (!isActive()) return;
+  if (!isMounted()) return;
   setUser(data);
 }, [id]);
 ```

--- a/index.js.flow
+++ b/index.js.flow
@@ -1,11 +1,11 @@
 declare module 'use-async-effect' {
   declare function useAsyncEffect(
-    effect: (isActive: () => boolean) => any | Promise<any>,
+    effect: (isMounted: () => boolean) => any | Promise<any>,
     inputs?: any[]
   ): void;
 
   declare function useAsyncEffect<V>(
-    effect: (isActive: () => boolean) => V | Promise<V>,
+    effect: (isMounted: () => boolean) => V | Promise<V>,
     destroy?: ?(result?: V) => void,
     inputs?: any[]
   ): void;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,11 +1,11 @@
 // TypeScript Version: 3.0
 export function useAsyncEffect(
-  effect: (isActive: () => boolean) => unknown | Promise<unknown>,
+  effect: (isMounted: () => boolean) => unknown | Promise<unknown>,
   inputs?: any[]
 ): void;
 
 export function useAsyncEffect<V>(
-  effect: (isActive: () => boolean) => V | Promise<V>,
+  effect: (isMounted: () => boolean) => V | Promise<V>,
   destroy?: (result?: V) => void,
   inputs?: any[]
 ): void;

--- a/types/test.ts
+++ b/types/test.ts
@@ -4,7 +4,7 @@ import useEffect, { useAsyncEffect } from 'use-async-effect';
 useAsyncEffect();
 
 // $ExpectType void
-useAsyncEffect((isActive) => {});
+useAsyncEffect((isMounted) => {});
 
 // $ExpectType void
 useEffect(async () => {});


### PR DESCRIPTION
Your source uses `mounted` internally but the types suggest using `isActive` instead:

https://github.com/rauldeheer/use-async-effect/blob/c20d83159cf5128c40a84722c563a7ba42524944/index.js#L11-L12


https://github.com/rauldeheer/use-async-effect/blob/c20d83159cf5128c40a84722c563a7ba42524944/types/index.d.ts#L7-L8


> I think `isMounted` is a more common name for the variable
> 
> It reflects if the React component is still in the React tree and is present in the DOM. `iaActive` is something that we often use in relation with an active tab, or window, or an item selected in the UI.

From https://github.com/pixiebrix/pixiebrix-extension/pull/3915#discussion_r934402704